### PR TITLE
Add increment/decrement counters to LWW

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,82 +196,73 @@ Return the original JSON. Because all patches are rejected when error occurs.
 assert(prevObject === nextObject);
 ```
 
-## Syncing using Last-Write-Wins
+## Syncing Objects
 
-This provides utilities that will help sync an object field-by-field using last-writer-wins. This sync method is a bit
-limited but stores little data in addition to the object. It does not work with array items, though entire arrays can
-be set. It doesn't work with "move" or "copy" operations, only "add", "remove", and "replace" operations are permitted
-with LWW. It should work great for documents like Figma describes in
+This library provides a utility that will help sync an object field-by-field using the Last-Write-Wins (LWW) algorithm.
+This sync method is not as robust as operational transformation, but it only stores a little data in addition to the
+object and is much simpler. It does not handle adding/removing array items, though entire arrays can
+be set. It should work great for documents like Figma describes in
 https://www.figma.com/blog/how-figmas-multiplayer-technology-works/ and for objects like user preferences.
 
-It works by using a metadata object to track the current revision of the object, any outstanding changes needing to be
-sent to the server, and the revisions of each added value so that one may get all changes since a given revision. It
-will be very small on the client, and only moderately sized on the server. It is up to the implementor to store this
-metadata object with the rest of the data. These are tools to help you deal with the harder part of LWW syncing, but
-you'll have to implement them in your system.
+It works by using metadata to track the current revision of the object, any outstanding changes needing to be sent to
+the server from the client, and the revisions of each added value on the server so that one may get all changes since
+the last revision it was synced. The metadata will be very small on the client, and smallish on the server. It is up to
+you to store this metadata with the rest of the object. These are tools to help you deal with the harder part of LWW
+syncing, but you'll have to implement it in your system.
 
-It should work with clients offline, though those clients will "win" when they come back online and write to the server.
-If this is not desired, simply send the data from the server down when first connecting and then just receive changes.
+It should work with clients offline, though those clients will "win" when they come back online and write their changes
+to the server. If this is not desired, simply send the data from the server down when first connecting and then just
+receive changes.
 
-It includes a whitelist or blacklist (not both) of properties that cannot be set by the client, only set by the server
-itself.
-
-You can use the Last-Write-Wins (LWW) strategy at property granularity with JSON Patch to sync object changes between
-clients and a server. LWWServer and LWWClient help you to manage the updates between client & server. Each object
-requires metadata to be stored and loaded alongside it. Consider storing like { data: { ... }, meta: { ...} }.
-
-Note: The client requires the server sending to be called within the `sendChanges` method which is necessary to avoid
-the property flickering described well here
-https://www.figma.com/blog/how-figmas-multiplayer-technology-works/#syncing-object-properties.
-
+It includes a whitelist and blacklist of properties that cannot be set by the client, only set by the server.
 
 On the client:
 ```js
-import { applyPatch, lwwClient } from '@typewriter/json-patch';
+import { applyPatch, syncableObject } from '@typewriter/json-patch';
 
 // Create a new LWW object
-const newObject = lwwClient({ baz: 'qux', foo: 'bar' });
+const newObject = syncableObject({ baz: 'qux', foo: 'bar' });
 
 // Send the initial object to the server
-newObject.sendChanges(async patch => {
+newObject.send(async patch => {
   // A function you define using fetch, websockets, etc
   await sendJSONPatchChangesToServer(patch);
 });
 
-// Or load an LWW object from storage or from the server
+// Or load a syncable object from storage (or from the server)
 const { data, metadata } = JSON.parse(localStorage.getItem('my-object-key'));
-const object = lwwClient(data, metadata);
+const object = syncableObject(data, metadata);
 
 // Automatically send changes when changes happen.
-// This will be called immediately if there are outstanding changes needing to be sent. Always send changes first before
-// asking for the latest from the server, otherwise local changes will be overwritten by the latest from the server.
-object.onMakeChange(() => {
-  object.sendChanges(async patch => {
-    // A function you define using fetch, websockets, etc
-    await sendJSONPatchChangesToServer(patch);
-  });
+// This will be called immediately if there are outstanding changes needing to be sent.
+object.subscribe((data, meta, hasUnsentChanges) => {
+  if (hasUnsentChanges) {
+    object.send(async patch => {
+      // A function you define using fetch, websockets, etc. Be sure to use await/promises to know when it is complete
+      // or errored. Place the try/catch around send, not inside
+      await sendJSONPatchChangesToServer(patch);
+    });
+  }
 });
 
 // Get changes since last synced after sending any outstanding changes
 const response = await getJSONPatchChangesFromServer(object.getRev());
 if (response.patch && response.rev) {
-  object.receiveChanges(response.patch, response.rev);
+  object.receive(response.patch, response.rev);
 }
 
-// When receiving a change from the server (onReceiveChanges is a method created by you, could use websockets or
-// polling, etc)
+// When receiving a change from the server, call receive
+// (`onReceiveChanges` is a method created by you, could use websockets or polling, etc)
 onReceiveChanges((patch, rev) => {
-  object.receiveChanges(patch, rev);
-  storeObject();
+  object.receive(patch, rev);
 });
 
 // persist to storage for offline use if desired. Will persist unsynced changes made offline.
-function storeObject() {
+object.subscribe((data, metadata) => {
   localStorage.setItem('my-object-key', JSON.stringify({
-    data: object.get(),
-    metadata: object.getMeta(),
+    data, metadata,
   }));
-}
+});
 ```
 
 On the server:

--- a/src/custom-types/delta.ts
+++ b/src/custom-types/delta.ts
@@ -60,6 +60,10 @@ export const text: JSONPatchCustomType = {
     return oldValue === undefined
       ? { op: 'remove', path }
       : { op: '@text', path, value: delta.invert(oldValue) };
+  },
+
+  compose(op1, op2) {
+    return new Delta(op1.value).compose(new Delta(op2.value));
   }
 };
 

--- a/src/custom-types/increment.ts
+++ b/src/custom-types/increment.ts
@@ -19,16 +19,23 @@ import type { JSONPatchCustomType } from '../types';
  *   increment(path: string, value: number) {
  *     return this.op('@inc', path, value);
  *   }
+ *
+ *   decrement(path: string, value: number) {
+ *     return this.op('@inc', path, -value);
+ *   }
  * }
  */
 export const increment: JSONPatchCustomType = {
-  apply: (path, value) => {
+  apply(path, value) {
     return applyOps.replace(path, (applyOps.get(path) || 0) + value);
   },
-  rebase: (over, ops) => {
+  rebase(over, ops) {
     return rebaseOps.replace(over, ops);
   },
-  invert: (op, value, changedObj) => {
+  invert(op, value, changedObj) {
     return invertOps.replace(op, value, changedObj);
-  }
+  },
+  compose(op1, op2) {
+    return op1.value + op2.value;
+  },
 }

--- a/src/custom-types/text-document.ts
+++ b/src/custom-types/text-document.ts
@@ -62,6 +62,10 @@ export const changeText: JSONPatchCustomType = {
     return oldValue === undefined
       ? { op: 'remove', path }
       : { op: '@changeText', path, value: delta.invert(oldValue.toDelta()) };
+  },
+
+  compose(op1, op2) {
+    return new Delta(op1.value).compose(new Delta(op2.value));
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export { applyPatch } from './applyPatch';
 export { JSONPatch } from './jsonPatch';
 export * from './apply/utils';
 export * from './rebase/utils';
-export * from './lww';
+export * from './syncable';
 export * as applyOps from './apply/ops';
 export * as rebaseOps from './rebase/ops';
 export * as invertOps from './invert/ops';

--- a/src/jsonPatch.ts
+++ b/src/jsonPatch.ts
@@ -14,6 +14,7 @@ import type { JSONPatchOp, JSONPatchCustomTypes, ApplyJSONPatchOptions } from '.
 import { applyPatch } from './applyPatch';
 import { rebasePatch } from './rebasePatch';
 import { invertPatch } from './invertPatch';
+import { increment } from './custom-types/increment';
 
 
 
@@ -31,6 +32,8 @@ export class JSONPatch {
   constructor(ops: JSONPatchOp[] = [], types: JSONPatchCustomTypes = {}) {
     this.ops = ops;
     this.types = types;
+    // Include as a default type since it is so common and so small
+    types['@inc'] = increment;
   }
 
   op(op: string, path: string, value?: any, from?: string) {
@@ -86,6 +89,20 @@ export class JSONPatch {
    */
   move(from: string, path: string) {
     return this.op('move', path, undefined, from);
+  }
+
+  /**
+   * Increments a numeric value by 1 or the given amount.
+   */
+  increment(path: string, value: number = 1) {
+    return this.op('@inc', path, value);
+  }
+
+  /**
+   * Decrements a numeric value by 1 or the given amount.
+   */
+  decrement(path: string, value: number = 1) {
+    return this.op('@inc', path, -value);
   }
 
   /**

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,46 +1,48 @@
-import { increment } from './custom-types/increment';
 import { JSONPatch } from './jsonPatch';
-import { lwwClient, LWWClient, lwwServer } from './lww';
+import { syncable, SyncableClient } from './syncable';
 
 
 test();
 
 
 async function test() {
-  const options = { types: { '@inc': increment }, blacklist: new Set([ '/foos' ])};
+  const options = { blacklist: new Set([ '/foos' ])};
 
-  const client1 = lwwClient({}, undefined, options);
-  const client2 = lwwClient({}, undefined, options);
-  const server = lwwServer({}, undefined, options);
+  const client1 = syncable({}, undefined, options);
+  const client2 = syncable({}, undefined, options);
+  const server = syncable({}, undefined, { ...options, server: true });
   const clients = [ client1, client2 ];
 
-  const sendChanges = async (client: LWWClient) => {
-    await client.sendChanges(async changes => {
+  // Control when changes are sent to test client-server interaction.
+  const sendChanges = async (client: SyncableClient) => {
+    await client.send(async changes => {
       await Promise.resolve();
-      server.receiveChange(changes);
+      server.receive(changes);
     });
   };
 
   server.onPatch((patch, rev) => {
-    console.log(rev, patch);
-    clients.forEach(client => client.receiveChange(patch, rev));
+    // console.log(rev, patch);
+    clients.forEach(client => client.receive(patch, rev));
   });
 
-  client1.makeChange(new JSONPatch().add('/thing', {}).add('/thing/stuff', 'green jello').toJSON());
+  client1.change(new JSONPatch().add('/thing', {}).add('/thing/stuff', 'green jello').toJSON());
   await sendChanges(client1);
   client2.set(client1.get(), client1.getMeta());
 
 
-  client1.makeChange(new JSONPatch().add('/test', 'out').increment('/foo', 2).add('/thing', {foobar: true}).toJSON());
-  client2.makeChange(new JSONPatch().increment('/foo', 5).add('/thing/asdf', 'qwer').toJSON());
+  client1.change(new JSONPatch().add('/test', 'out').increment('/foo', 2).add('/thing', {foobar: true}).toJSON());
+  client2.change(new JSONPatch().increment('/foo', 5).add('/thing/asdf', 'qwer').toJSON());
 
   await Promise.all([
     sendChanges(client1),
     sendChanges(client2),
   ]);
 
-  client2.makeChange(new JSONPatch().remove('/thing/asdf').increment('/foo').toJSON());
+  client2.change(new JSONPatch().remove('/thing/asdf').increment('/foo').toJSON());
   await sendChanges(client2);
+
+  console.log(server.changesSince(2));
 
   process.stdout.write([
     JSON.stringify([ server.get(), server.getMeta() ], null, 2),

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,3 +1,4 @@
+import { increment } from './custom-types/increment';
 import { JSONPatch } from './jsonPatch';
 import { lwwClient, LWWClient, lwwServer } from './lww';
 
@@ -6,7 +7,7 @@ test();
 
 
 async function test() {
-  const options = { blacklist: new Set([ '/foo' ])};
+  const options = { types: { '@inc': increment }, blacklist: new Set([ '/foos' ])};
 
   const client1 = lwwClient({}, undefined, options);
   const client2 = lwwClient({}, undefined, options);
@@ -21,21 +22,25 @@ async function test() {
   };
 
   server.onPatch((patch, rev) => {
+    console.log(rev, patch);
     clients.forEach(client => client.receiveChange(patch, rev));
   });
 
   client1.makeChange(new JSONPatch().add('/thing', {}).add('/thing/stuff', 'green jello').toJSON());
   await sendChanges(client1);
-  // client2.set(client1.get(), client1.getMeta());
+  client2.set(client1.get(), client1.getMeta());
 
 
-  client1.makeChange(new JSONPatch().add('/test', 'out').add('/foo', 'bar').add('/thing', {foobar: true}).toJSON());
-  client2.makeChange(new JSONPatch().add('/foo', '######').add('/thing/asdf', 'qwer').toJSON());
+  client1.makeChange(new JSONPatch().add('/test', 'out').increment('/foo', 2).add('/thing', {foobar: true}).toJSON());
+  client2.makeChange(new JSONPatch().increment('/foo', 5).add('/thing/asdf', 'qwer').toJSON());
 
   await Promise.all([
     sendChanges(client1),
     sendChanges(client2),
   ]);
+
+  client2.makeChange(new JSONPatch().remove('/thing/asdf').increment('/foo').toJSON());
+  await sendChanges(client2);
 
   process.stdout.write([
     JSON.stringify([ server.get(), server.getMeta() ], null, 2),

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface JSONPatchCustomType {
   apply?: ApplyHandler;
   rebase?: RebaseHandler;
   invert?: InvertHandler;
+  compose?: ComposeHandler;
 }
 
 export interface JSONPatchCustomTypes {
@@ -31,3 +32,4 @@ export interface Root {
 export type ApplyHandler = (path: string, value: any, from: string) => string | void;
 export type RebaseHandler = (over: JSONPatchOp, ops: JSONPatchOp[]) => JSONPatchOp[];
 export type InvertHandler = (op: JSONPatchOp, value: any, changedObj: any, isIndex: boolean) => JSONPatchOp;
+export type ComposeHandler = (value1: any, value2: any) => any;


### PR DESCRIPTION
Allow the client to use @inc change ops which will merge nicely on the server. The server will always send the total count down as the source of truth. Clients should always send their changes up as soon as they are made.