### PR TITLE
Provide a more sure way to check if a path is an array

### DIFF
--- a/src/jsonPatch.ts
+++ b/src/jsonPatch.ts
@@ -148,8 +148,8 @@ export class JSONPatch {
   /**
    * Rebase this patch against another JSONPatch or array of operations
    */
-  rebase(over: JSONPatch | JSONPatchOp[]) {
-    return new JSONPatch(rebasePatch(this.ops, Array.isArray(over) ? over : over.ops, this.types));
+  rebase(over: JSONPatch | JSONPatchOp[], obj?: any) {
+    return new JSONPatch(rebasePatch(this.ops, Array.isArray(over) ? over : over.ops, this.types, obj));
   }
 
   /**

--- a/src/rebase/utils/isArrayPath.ts
+++ b/src/rebase/utils/isArrayPath.ts
@@ -1,8 +1,14 @@
+import { root } from '../../apply/state';
+import { getOpData } from '../../apply/utils';
+
 const arrayPathExp = /\/(0|[1-9]\d*)$/;
 
 /**
  * Check if the path is to an array index and return the prefix and index.
  */
 export function isArrayPath(path: string) {
-  return arrayPathExp.test(path);
+  if (!arrayPathExp.test(path)) return false;
+  if (!root || !root['']) return true;
+  const [ _, __, target ] = getOpData(path);
+  return Array.isArray(target);
 }

--- a/src/rebasePatch.ts
+++ b/src/rebasePatch.ts
@@ -15,6 +15,7 @@ import { filterNoops } from './rebase/utils/ops';
 import * as rebases from './rebase/ops';
 import { log } from './rebase/utils/log';
 import { RebaseHandler } from '.';
+import { patchWith } from './apply/state';
 
 
 /**
@@ -22,16 +23,18 @@ import { RebaseHandler } from '.';
  * rebased operations. Operations that do not change are left, while operations that do change are cloned, making the
  * results of this function immutable.
  */
-export function rebasePatch(ops: JSONPatchOp[], overOps: JSONPatchOp[], types: JSONPatchCustomTypes = {}): JSONPatchOp[] {
-  return overOps.reduce((ops: JSONPatchOp[], over: JSONPatchOp) => {
-    // rebase ops with patch operation
-    const handler = types[over.op]?.rebase || (rebases as {[name: string]: RebaseHandler})[over.op];
-    if (typeof handler === 'function') {
-      ops = handler(over, ops);
-    } else {
-      log('No function to rebase against for', over.op);
-    }
+export function rebasePatch(ops: JSONPatchOp[], overOps: JSONPatchOp[], types: JSONPatchCustomTypes = {}, object?: any): JSONPatchOp[] {
+  return patchWith(object, false, () => {
+    return overOps.reduce((ops: JSONPatchOp[], over: JSONPatchOp) => {
+      // rebase ops with patch operation
+      const handler = types[over.op]?.rebase || (rebases as {[name: string]: RebaseHandler})[over.op];
+      if (typeof handler === 'function') {
+        ops = handler(over, ops);
+      } else {
+        log('No function to rebase against for', over.op);
+      }
 
-    return ops;
-  }, filterNoops(ops));
+      return ops;
+    }, filterNoops(ops));
+  });
 }


### PR DESCRIPTION
We can only really know if a path is an array vs a property on an object by providing the source object the ops are meant to be applied to. In order to prevent a backwards incompatible change, I made it an optional parameter at the end of `rebase` but it really _should_ be used in every case. We could remove the ? and make it required in the future.